### PR TITLE
Map billing list on Magento module

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -22,6 +22,8 @@ var config = {
                 'Improntus_Moova/js/view/shipping-address/address-renderer/default',
             'Magento_Checkout/js/view/billing-address':
                 'Improntus_Moova/js/view/billing-address',
+            'Magento_Checkout/js/view/billing-address/list':
+                'Magento_Checkout/js/view/billing-address/list',
             'Magento_Checkout/js/view/shipping-information/address-renderer/default':
                 'Improntus_Moova/js/view/shipping-information/address-renderer/default',
             'Magento_Checkout/template/billing-address':


### PR DESCRIPTION
Without this two lines, magento will try to request `Improntus_Moova/js/view/billing-address/list.js` instead of `Magento_Checkout/js/view/billing-address/list.js`